### PR TITLE
fix: typePrefix empty

### DIFF
--- a/lib/src/fields.dart
+++ b/lib/src/fields.dart
@@ -112,7 +112,7 @@ abstract class Field<T> {
     if (typePrefix == 'dart.core') {
       return type;
     }
-    return '${typePrefix != null ? '$typePrefix.' : ''}$type';
+    return '${typePrefix?.isNotEmpty ?? false ? '$typePrefix.' : ''}$type';
   }
 
   /// Checks if the field is nullable.


### PR DESCRIPTION
For some reason when using enums, the typePrefix value is not null but is empty, which causes an error when generating the code, therefore this validation is necessary for it to work with enums.